### PR TITLE
refactor(cron): change goal reminder from daily to hourly execution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,8 @@ FIREBASE_CLIENT_EMAIL=firebase-adminsdk-xxxxx@your-project.iam.gserviceaccount.c
 # POINTHUB CONFIG
 POINTHUB_SECRET=secret
 # CRON CONFIG
-# Goal reminder cron job - sends FCM notifications for goals with H-1 deadline
-CRON_GOAL_REMINDER_HOUR=6
+# Goal reminder cron job - runs every hour and sends FCM notifications
+# for goals with deadline in the same hour tomorrow (H-1)
+# Example: At 9:00 AM, it notifies users about goals due 9:00-9:59 AM tomorrow
 CRON_GOAL_REMINDER_MINUTE=0
 CRON_TIMEZONE=Asia/Jakarta

--- a/src/cron/goal-reminder.ts
+++ b/src/cron/goal-reminder.ts
@@ -12,38 +12,44 @@ interface IUserWithFcmTokens {
 /**
  * Goal Reminder Cron Job
  *
- * This job checks for goals with target date (time field) that is H-1 (1 day before deadline)
- * and sends FCM push notifications to remind users.
+ * This job runs every hour and checks for goals with target date (time field)
+ * that falls within the same hour tomorrow.
+ *
+ * Example: If the cron runs at 9:00 AM today, it will send notifications for
+ * goals with deadline between 9:00 AM - 9:59 AM tomorrow.
  */
 export async function runGoalReminderJob(dbConnection: IDatabase): Promise<void> {
   console.log('[Goal Reminder] Starting goal reminder job...');
 
   const now = new Date();
+  const currentHour = now.getHours();
 
-  // Calculate tomorrow's date range (H-1 means target is tomorrow)
-  const tomorrowStart = new Date(now);
-  tomorrowStart.setDate(tomorrowStart.getDate() + 1);
-  tomorrowStart.setHours(0, 0, 0, 0);
+  // Calculate tomorrow's hour range
+  // If cron runs at 9:00 AM today, check for goals with deadline 9:00 AM - 9:59 AM tomorrow
+  const tomorrowHourStart = new Date(now);
+  tomorrowHourStart.setDate(tomorrowHourStart.getDate() + 1);
+  tomorrowHourStart.setHours(currentHour, 0, 0, 0);
 
-  const tomorrowEnd = new Date(tomorrowStart);
-  tomorrowEnd.setHours(23, 59, 59, 999);
+  const tomorrowHourEnd = new Date(tomorrowHourStart);
+  tomorrowHourEnd.setMinutes(59, 59, 999);
 
-  console.log(`[Goal Reminder] Checking goals with deadline between ${tomorrowStart.toISOString()} and ${tomorrowEnd.toISOString()}`);
+  console.log(`[Goal Reminder] Current hour: ${currentHour}:00`);
+  console.log(`[Goal Reminder] Checking goals with deadline between ${tomorrowHourStart.toISOString()} and ${tomorrowHourEnd.toISOString()}`);
 
   try {
-    // Find goals with target date (time field) that is tomorrow and status is in-progress
+    // Find goals with target date (time field) that falls within the same hour tomorrow and status is in-progress
     const goalsResponse = await dbConnection.collection('goals').retrieveAll({
       filter: {
         time: {
-          $gte: tomorrowStart,
-          $lte: tomorrowEnd,
+          $gte: tomorrowHourStart,
+          $lte: tomorrowHourEnd,
         },
         status: 'in-progress',
       },
     });
 
     const goals = goalsResponse.data as IGoalEntity[];
-    console.log(`[Goal Reminder] Found ${goals.length} goals with deadline tomorrow`);
+    console.log(`[Goal Reminder] Found ${goals.length} goals with deadline tomorrow at ${currentHour}:00-${currentHour}:59`);
 
     if (goals.length === 0) {
       console.log('[Goal Reminder] No goals to remind. Job completed.');

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -6,8 +6,7 @@ import { runGoalReminderJob } from './goal-reminder';
  * Cron Scheduler Configuration
  */
 export interface ICronConfig {
-  goalReminderHour: number // Hour in 24-hour format (0-23)
-  goalReminderMinute: number // Minute (0-59)
+  goalReminderMinute: number // Minute of each hour to run (0-59)
   timezone: string // Timezone for scheduling
 }
 
@@ -15,67 +14,58 @@ export interface ICronConfig {
  * Get cron configuration from environment variables
  */
 export function getCronConfig(): ICronConfig {
-  const hourStr = process.env['CRON_GOAL_REMINDER_HOUR'] || '8';
   const minuteStr = process.env['CRON_GOAL_REMINDER_MINUTE'] || '0';
   const timezone = process.env['CRON_TIMEZONE'] || 'Asia/Jakarta';
 
-  const hour = parseInt(hourStr, 10);
   const minute = parseInt(minuteStr, 10);
-
-  // Validate hour (0-23)
-  if (isNaN(hour) || hour < 0 || hour > 23) {
-    console.warn(`[Cron] Invalid CRON_GOAL_REMINDER_HOUR: ${hourStr}, using default 8`);
-    return { goalReminderHour: 8, goalReminderMinute: 0, timezone };
-  }
 
   // Validate minute (0-59)
   if (isNaN(minute) || minute < 0 || minute > 59) {
     console.warn(`[Cron] Invalid CRON_GOAL_REMINDER_MINUTE: ${minuteStr}, using default 0`);
-    return { goalReminderHour: hour, goalReminderMinute: 0, timezone };
+    return { goalReminderMinute: 0, timezone };
   }
 
-  return { goalReminderHour: hour, goalReminderMinute: minute, timezone };
+  return { goalReminderMinute: minute, timezone };
 }
 
 /**
- * Calculate milliseconds until next scheduled time
+ * Calculate milliseconds until next hourly run
+ * The job runs every hour at the specified minute
  */
-function getMillisecondsUntilNextRun(targetHour: number, targetMinute: number): number {
+function getMillisecondsUntilNextHourlyRun(targetMinute: number): number {
   const now = new Date();
   const next = new Date(now);
 
-  next.setHours(targetHour, targetMinute, 0, 0);
+  next.setMinutes(targetMinute, 0, 0);
 
-  // If the target time has already passed today, schedule for tomorrow
+  // If the target minute has already passed this hour, schedule for next hour
   if (next <= now) {
-    next.setDate(next.getDate() + 1);
+    next.setHours(next.getHours() + 1);
   }
 
   return next.getTime() - now.getTime();
 }
 
 /**
- * Format time for logging
- */
-function formatTime(hour: number, minute: number): string {
-  return `${hour.toString().padStart(2, '0')}:${minute.toString().padStart(2, '0')}`;
-}
-
-/**
  * Start the cron scheduler
  *
- * This scheduler runs jobs at specific times each day.
+ * This scheduler runs the goal reminder job every hour at the specified minute.
  * It uses setTimeout to schedule the next run, which is more accurate
- * than setInterval for daily jobs.
+ * than setInterval for hourly jobs.
+ *
+ * Example: If CRON_GOAL_REMINDER_MINUTE=0, the job runs at:
+ * - 00:00, 01:00, 02:00, ..., 23:00 every day
+ *
+ * Each run checks for goals with deadline in the same hour tomorrow.
  */
 export function startCronScheduler(dbConnection: IDatabase): void {
   const config = getCronConfig();
 
   console.log('[Cron] Starting cron scheduler');
-  console.log(`[Cron] Goal reminder scheduled at ${formatTime(config.goalReminderHour, config.goalReminderMinute)} (${config.timezone})`);
+  console.log(`[Cron] Goal reminder scheduled to run every hour at minute :${config.goalReminderMinute.toString().padStart(2, '0')} (${config.timezone})`);
 
   const scheduleNextRun = () => {
-    const msUntilNextRun = getMillisecondsUntilNextRun(config.goalReminderHour, config.goalReminderMinute);
+    const msUntilNextRun = getMillisecondsUntilNextHourlyRun(config.goalReminderMinute);
     const nextRunDate = new Date(Date.now() + msUntilNextRun);
 
     console.log(`[Cron] Next goal reminder scheduled for: ${nextRunDate.toISOString()}`);
@@ -89,7 +79,7 @@ export function startCronScheduler(dbConnection: IDatabase): void {
         console.error('[Cron] Error in goal reminder job:', error);
       }
 
-      // Schedule the next run
+      // Schedule the next run (next hour)
       scheduleNextRun();
     }, msUntilNextRun);
   };


### PR DESCRIPTION
Change the goal reminder cron job from running once daily to running every hour. When executed, the job now checks for goals with deadlines in the same hour tomorrow, rather than checking all goals due tomorrow.

This provides more granular notification timing aligned with the specific hour when goals are due.

- Remove CRON_GOAL_REMINDER_HOUR config, keep only MINUTE
- Update time range check from full day to hourly window
- Modify scheduler to run every hour instead of once per day
- Update comments and documentation to reflect hourly execution